### PR TITLE
First draft of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release Extension
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: npm install
+      - name: Create extension zip
+        run: |
+          ls
+          zip -r ${{github.event.repository.name}}.zip .
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{github.event.repository.name}}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,21 +7,53 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: 📦 Build Extension
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-18.04, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
         run: npm install
-      - name: Create extension zip
+      - name: Create extension zip (Mac)
+        if: runner.os == 'macOS'
+        shell: bash
         run: |
-          ls
-          zip -r ${{github.event.repository.name}}.zip .
+          zip -r ${{github.event.repository.name}}-macos.zip .
+      - name: Create extension zip (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          zip -r ${{github.event.repository.name}}-linux.zip .
+      - name: Create extension zip (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Compress-Archive -Path ${Env:GITHUB_WORKSPACE} -DestinationPath ${{github.event.repository.name}}-windows.zip
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ${{github.event.repository.name}}-*.zip
+  
+  release:
+    name: 🚀 Create Release
+    runs-on: ubuntu-18.04
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: dist/
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ${{github.event.repository.name}}.zip
+            dist/artifact/${{github.event.repository.name}}-linux.zip
+            dist/artifact/${{github.event.repository.name}}-macos.zip
+            dist/artifact/${{github.event.repository.name}}-windows.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,13 +4,21 @@ Interested in creating an extension for TwilioQuest? You've come to the right pl
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Getting Started](#getting-started)
-  - [Enabling extensions](#enabling-extensions)
-- [Creating an Extension](#creating-an-extension)
-  - [Working on your extension locally](#working-on-your-extension-locally)
-  - [Extension development topics](#extension-development-topics)
-- [Extension Development Help](#extension-development-help)
-- [License](#license)
+- [TwilioQuest Extension Template](#twilioquest-extension-template)
+  - [Getting Started](#getting-started)
+    - [Enabling extensions](#enabling-extensions)
+  - [Creating an Extension](#creating-an-extension)
+    - [Working on your extension locally](#working-on-your-extension-locally)
+    - [Extension development topics](#extension-development-topics)
+      - [Level configuation.json file options](#level-configuationjson-file-options)
+        - [Background Effects](#background-effects)
+    - [Example Gists](#example-gists)
+      - [Objective Validator.js Examples](#objective-validatorjs-examples)
+  - [Sharing your Extension](#sharing-your-extension)
+    - [Enable GitHub Actions](#enable-github-actions)
+    - [Create a Release](#create-a-release)
+  - [Extension Development Help](#extension-development-help)
+  - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -117,6 +125,26 @@ During the early development phase of our content authoring tools, our documenta
 - Adding custom tile maps
 - Music and sound effects
 - Distributing your extension to players
+  
+## Sharing your Extension
+Other TwilioQuest players can install your extension by following the steps in [Enabling Extensions](#enabling-extensions) on their own machines, and then placing your extension in the folder they specified for extensions.
+
+A player may have to install any dependencies before they can use your extension. This repository includes a [GitHub Action workflow](/.github/workflows/release.yml) that will install any Javascript dependencies, and publish a ready to use zip file of your extension as a [Release](/releases).
+
+Please note that the workflow by default only installs and bundles Javascript dependencies. If you are using other language ecosystems in your extension, those dependencies will not be included by default, but you can add your own build steps to the workflow.
+
+Follow the steps below to use the workflow to publish your extension:
+
+### Enable GitHub Actions
+
+- Open the [Actions](/actions) tab on the repository.
+- Follow the prompt to enable GitHub Actions for the repository.
+
+### Create a Release
+
+- A release is created on [tagged](https://git-scm.com/book/en/v2/Git-Basics-Tagging) pushes.
+- The tag must be a version number, representing the version of the extension, following [SemVer](https://semver.org/), for example `v1.0.0`.
+- When a push is made with a valid tag, the GitHub Action will create a release and add it to the [Releases](/releases) tab. The release can be edited, to add information such as changelogs or patchnotes.
 
 [<< TO TABLE OF CONTENTS](#twilioquest-extension-template)
 


### PR DESCRIPTION
This pull request adds an initial action for bundling up an extension as a .zip with dependencies including.

How it works:
- on `push`, tagged with a semver tag, i.e. `v1.0.0`
- runs `npm install` to grab JS dependencies
- creates a zip
- creates release with zip

This is pretty basic currently, some things to think about:
- Non-JS dependencies. What, if anything, can we do to help extension devs bundle dependencies they add? Low hanging fruit is tutorial on extending the workflow. 
- The release is bare-bones. There's some easy actions for automatically creating release notes from PRs and commits
- Other validation/build steps. Now we've opened the door on including workflow files, there is probably other workflows we can add that smooth out the development process. I.e. json validation.



