### PR TITLE
Docs: fix link to actions tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Follow the steps below to use the workflow to publish your extension:
 
 ### Enable GitHub Actions
 
-- Open the [Actions](/actions) tab on the repository.
+- Open the [Actions](/../../actions) tab on the repository.
 - Follow the prompt to enable GitHub Actions for the repository.
 
 ### Create a Release


### PR DESCRIPTION
The link to the actions tab in the Readme leads to 404. This PR should fix that